### PR TITLE
ci: use runner.arch in cache path

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-${{ runner.arch }}-buildx-
       - id: meta
         uses: docker/metadata-action@v3
         with:
@@ -57,9 +57,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-${{ runner.arch }}-buildx-
       - id: meta
         uses: docker/metadata-action@v3
         with:


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>