### PR TITLE
ci: use ghcr.io repository in meta-ghcr-tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,7 +188,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>